### PR TITLE
Update port to 50052 in  in grpc_server.py

### DIFF
--- a/grpc_server.py
+++ b/grpc_server.py
@@ -50,7 +50,7 @@ def serve(port, max_workers):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process some integers.')
-    parser.add_argument('--port', type=int, help='port number', required=False, default=5052)
+    parser.add_argument('--port', type=int, help='port number', required=False, default=50052)
     parser.add_argument('--max_workers', type=int, help='# max workers', required=False, default=10)
     args = parser.parse_args()
 


### PR DESCRIPTION
Following the instructions in the readme.md does not work unless the default port is changed from 5052 to 50052 in grpc_server.py (I am guessing this was a typo).
Change port from 5052 to 50052 in grpc_server.py